### PR TITLE
Fixing intervals and netcdf plotting filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 !/.gitignore
 !.gitkeep
 
+# Ignore output folder
+./output/
+
 # Ignore data (.csv, .dat and .nc) files
 *.csv
 *.dat

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 !.gitkeep
 
 # Ignore output folder
-./output/
+./outputs/
 
 # Ignore data (.csv, .dat and .nc) files
 *.csv

--- a/src/SatelliteCoverage/config.py
+++ b/src/SatelliteCoverage/config.py
@@ -1,5 +1,5 @@
 """
-Author: Lekima Yakuden 
+Author: Lekima Yakuden
 GitHub: LekiYak
 
 --------------------------------------------------------------------------------
@@ -41,12 +41,12 @@ def read_config():
     return config
 
 """
-Raw Data 
+Raw Data
 """
 # Compiles raw data into pandas dataframe
 def compile_data(raw_paths):
 
-    """ 
+    """
     Compiles all data points in the list of data files (raw_paths) into a dataframe (df)
 
     Returns the dataframe with all datapoints' starting lat and lon in columns.
@@ -54,7 +54,7 @@ def compile_data(raw_paths):
     INPUTS:
     raw_paths -- List of paths to data files {List}
 
-    OUTPUTS: 
+    OUTPUTS:
     df -- Pandas dataframe with the following columns: Index  lat  lon {Dataframe}
     """
 
@@ -66,7 +66,7 @@ def compile_data(raw_paths):
 
     # Appending each file's datapoints to the dataframe
     for filepath in raw_paths:
-        
+
         # Initialize temporary dataframe
         temp_df = pd.DataFrame()
 
@@ -111,16 +111,16 @@ def convert_to_grid(lon, lat):
     return x, y
 
 # Divides raw data into intervals specified by the user
-def divide_intervals(raw_paths, max_date, min_date, interval):
+# def divide_intervals(raw_paths, max_date, min_date, interval):
+def divide_intervals(raw_paths, Date_options = None, Options = None):
     """
     Divides delta-t filtered data into chunks (intervals) of *interval* hours for
     processing.
 
     INPUTS:
     raw_paths -- List of data file paths with the desired delta t {list}
-    max_date -- Upper limit of selected date range {datetime object}
-    min_date -- Lower limit of selected date range {datetime object}
-    interval -- Desired interval length in hours {str}
+    Date_options -- ConfigParser object to determine start/end dates of intervals as specififed by user
+    Options -- ConfigParser object to determine the interval length as specififed by user
 
     OUTPUTS:
     interval_list -- List of n lists, where n is the number of full intervals which
@@ -129,18 +129,29 @@ def divide_intervals(raw_paths, max_date, min_date, interval):
                      with the n th interval.
     date_pairs -- List of tuples, each containing the start and end dates of the n th interval (datetime
                   objects in tuples, all in a list)
-    
+
     """
+    start_year  = str(Date_options['start_year'])
+    start_month = str(Date_options['start_month'])
+    start_day   = str(Date_options['start_day'])
+    end_year    = str(Date_options['end_year'])
+    end_month   = str(Date_options['end_month'])
+    end_day     = str(Date_options['end_day'])
+    interval    = Options['interval']
+
+    # Concatenate start and end dates
+    sDate = datetime.strptime(start_year + start_month + start_day, '%Y%m%d')
+    eDate = datetime.strptime(end_year + end_month + end_day, '%Y%m%d')
 
     # Converting date range to timedelta object (hours)
-    date_range = (max_date - min_date)
+    date_range = (eDate - sDate)
     date_range = date_range.days * 24
 
     # Counting number of full intervals over date range {int}
     interval_count = date_range // int(interval)
 
     # Allowing *min_date* to be updated and initializing time difference object
-    min_date_it = min_date
+    min_date_it = sDate
     dtime = timedelta(hours=int(interval))
 
     # Creating list containing tuples of date ranges [(dt1, dt2), (dt2, dt3) ...]
@@ -176,29 +187,20 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
     options in 'options.ini'. Outputs a list of paths to data files which
     satisfy the user's criteria.
 
-    Automatically changes date range to match data availability. i.e. if the user specifies
-    a date range between 01-11-2020 and 01-06-2021, but data is only available from 
-    05-11-2020 and 24-05-2021, dates to be processed will be set to the latter, and
-    the user will be notified (Line 
+    Note: If the available data does not span the full start/end dates interval
+    specified by the user in 'options.ini', the user will be informed that the
+    the files to be processed have a different time span the the one requested.
 
     INPUTS:
-    start_year -- Starting year YYYY {str}
-    start_month -- Starting month MM {str}
-    start_day -- Starting day DD {str}
+    Date_options -- ConfigParser object to determine start/end dates, timestep, and tolerance as specififed by user.
+    IO -- ConfigParser object to determine the path to directory containing the data files
+    Metadata -- ConfigParser object to determine which satellite(s) is being used.
 
-    end_year -- Ending year YYYY {str}
-    end_month -- Ending month MM {str}
-    end_day -- Ending day DD {str} 
-
-    timestep -- Desired timestep in hours {str}
-    tolerance -- Number of hours around timestep that will be filtered through {str}
-
-    data_path -- Path to directory containing data files {str}
 
     OUTPUTS:
     raw_paths -- List of file paths {list}
     """
-    
+
     start_year  = str(Date_options['start_year'])
     start_month = str(Date_options['start_month'])
     start_day   = str(Date_options['start_day'])
@@ -212,7 +214,7 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
     sDate = datetime.strptime(start_year + start_month + start_day, '%Y%m%d')
     eDate = datetime.strptime(end_year + end_month + end_day, '%Y%m%d')
 
-    # Set delta t tolerance 
+    # Set delta t tolerance
     upper_timestep = timedelta(hours=(int(timestep) + int(tolerance)))
     lower_timestep = timedelta(hours=(int(timestep) - int(tolerance)))
 
@@ -243,58 +245,58 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
                 print('No data for '+ sat_type + ' in ' + str(year) )
             else:
                 data_path = date_path + sat_type + str(year) + '/'
-    
+
                 #--------------------------------------------------------------------------
                 # listing the files in the folder and adding the pairs if in the right dates
                 #     This could be made a function if used when a IO class is made
                 #---------------------------------------------------------------------------
-    
+
                 # Filtering data files by date
                 for filename in os.listdir(data_path):
-                    
+
                     # Extracting initial and final dates from data file names
                     iDate = datetime.strptime(filename[6:20], '%Y%m%d%H%M%S')
                     fDate = datetime.strptime(filename[21:35], '%Y%m%d%H%M%S')
-            
+
                     # Checking if all files from iDate to fDate will be loaded (timestep == '0')
                     if timestep != '0':
                         # Filtering by date range and delta t and appending to the file list
-                        if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months: 
+                        # AB: THIS WAS THE ORIGINAL FILTER:
+                        # if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months:
+                        # AB: THIS IS WHAT I WOULD PROPOSE:
+                        if iDate < eDate and fDate > sDate and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months:
                             raw_paths.append(data_path + '/' + filename)
-            
-                            # Updating date tracker
-                            if iDate < min_date:
-                                min_date = iDate
-                            if fDate > max_date:
-                                max_date = fDate
-                    
-                    elif timestep == '0':
-                        # Filtering by date range only
-                        if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and iDate.month not in summer_months: 
-                            raw_paths.append(data_path + '/' + filename)
-                            
+
                             # Updating date tracker
                             if iDate < min_date:
                                 min_date = iDate
                             if fDate > max_date:
                                 max_date = fDate
 
-    # Force interval limit dates to start/end at 00:00:00
-    min_date = min_date.replace(hour=0,minute=0,second=0)
-    max_date = max_date.replace(hour=0,minute=0,second=0)
-    
-    # Notifying user of date range change
-    if sDate != min_date or eDate != max_date:
-        print(f"Start and end dates of data updated to {min_date} and {max_date}")
-            
-    return raw_paths, max_date, min_date      
+                    elif timestep == '0':
+                        # Filtering by date range only
+                        # AB: NEED TO CORRECT WITH THE SAME FILTER AS ABOVE HERE:
+                        if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and iDate.month not in summer_months:
+                            raw_paths.append(data_path + '/' + filename)
+
+                            # Updating date tracker
+                            if iDate < min_date:
+                                min_date = iDate
+                            if fDate > max_date:
+                                max_date = fDate
+
+    # Notifying user of data start/end times of files corresponding to the specified interval
+    print(f"Valid start/end dates of coverage map: {sDate} to {eDate}")
+    print(f"Earliest/latest start/end dates of data included in coverage map: {min_date} to {max_date}")
+
+    return raw_paths
 
 
 """
 netCDF Analysis
 """
 # Converts desired time range to seconds for netCDF analysis
-def seconds_to_date(path:str, start_year, start_month, start_day, end_year, end_month, end_day):
+def date_to_seconds(path:str, start_year, start_month, start_day, end_year, end_month, end_day):
     """
     This function takes in a netCDF's reference time and start and end times of each triangle
     and calculates the seconds elapsed between the former and latter. This is done to filter
@@ -337,6 +339,26 @@ def seconds_to_date(path:str, start_year, start_month, start_day, end_year, end_
 
     return start_ref_dt, end_ref_dt
 
+# Converts date in seconds from netCDF's reference time to datetime object
+def seconds_to_date(path:str, date_sec_in):
+    # Open dataset
+    ds = Dataset(path, mode='r')
+
+    # Fetch reference time (start timestamp)
+    reftime = ds.getncattr('referenceTime')
+
+    # Closing dataset
+    ds.close()
+
+    # Converting reference time from string to datetime object
+    reftime = reftime[0:10]
+    reftime = datetime.strptime(reftime, '%Y-%m-%d')
+
+    date_out = reftime+timedelta(seconds=int(date_sec_in))
+
+    return date_out
+
+
 # Filters netCDF data by area
 def filter_area(centre_lat, centre_lon, radius, start_lats, start_lons):
     """
@@ -349,9 +371,9 @@ def filter_area(centre_lat, centre_lon, radius, start_lats, start_lons):
     centre_lat -- Latitude of the centre point {float}
     centre_lon -- Longitude of the centre point {float}
     radius -- Radius of the circle (mask) in kilometres {float}
-    start_lats -- Starting latitudes of the triangles in the format 
+    start_lats -- Starting latitudes of the triangles in the format
                   [[Latitudes (1)], [Latitudes (2)], [Latitudes (3)]] {NumPy array}
-    start_lons -- Starting latitudes of the triangles in the format 
+    start_lons -- Starting latitudes of the triangles in the format
                   [[Longitudes (1)], [Longitudes (2)], [Longitudes (3)]] {NumPy array}
 
     OUTPUTS:
@@ -373,11 +395,11 @@ def filter_area(centre_lat, centre_lon, radius, start_lats, start_lons):
 
     # Iterating over all lists
     for coordinate in zip(start_lat1, start_lon1):
-        if hs.haversine(coordinate, centre_point) <= radius: # hs.haversine calculates the 
+        if hs.haversine(coordinate, centre_point) <= radius: # hs.haversine calculates the
             tf_list1.append(1)                               # distance between two lats/lons
         else:
             tf_list1.append(0)
-    
+
     for coordinate in zip(start_lat2, start_lon2):
         if hs.haversine(coordinate, centre_point) <= radius:
             tf_list2.append(1)
@@ -401,7 +423,7 @@ def load_netcdf(path:str):
     This function reads and loads data from a netCDF file in the same format as those output by the deformation
     calculation script in src/SeaIceDeformation. The user is able to filter the data by time and area,
     allowing for analytical tools to be applied to selected snippets of data.
-    
+
     INPUTS:
     path -- String of path to the netCDF file the data will be read from {str}
 
@@ -410,7 +432,7 @@ def load_netcdf(path:str):
     """
 
     print('--- Loading data ---')
-    
+
     # Reading config
     config = read_config()
     Date_options = config['Date_options']
@@ -425,26 +447,35 @@ def load_netcdf(path:str):
     ds = Dataset(path, mode='r')
 
     # Get start / end times from user
-    start_time_s, end_time_s = seconds_to_date(path, start_year, start_month, start_day, end_year, end_month, end_day)
+    start_time_s, end_time_s = date_to_seconds(path, start_year, start_month, start_day, end_year, end_month, end_day)
 
     # Extracting time variables
     start_time = ds.variables['start_time'][:]
     end_time = ds.variables['end_time'][:]
 
     # Indices of data in desired time frame
-    # AB: THIS NOW SELECTS ALL PAIRS THAT START OR END DURING THE PLOTTING TIME 
-    #     INTERVAL SPECIFIED IN [Date_options] IN 'options.ini'
-    #     !!!! MAYBE ADD A SECOND FILTER TO KEEP ONLY THOSE THAT HAVE A MINIMUM OF 
-    #     50% OF THEIR DT COVERING THE SELECTED PLOTTING TIME INTERVAL?
-    time_indices_s = np.where( (start_time > start_time_s) & (start_time < end_time_s) )[0]
-    time_indices_e = np.where( (end_time > start_time_s) & (start_time < start_time_s) )[0]
-    time_indices = np.unique(np.append(time_indices_s,time_indices_e))
-    
-    
-    # Extracting data (Filtered by time only)
+    # AB: THIS WAS THE ORIGINAL VERSION:
+    # time_indices = np.where( (start_time > start_time_s) & (start_time < end_time_s) )[0]
+
+    # AB: THIS WOULD CORRESPOND TO WHAT IS DONE COVERAGE FREQUENCY MAP:
+    # time_indices = []
+    # for i in range(len(start_time)):
+    #     sDate = seconds_to_date(path,start_time_s)
+    #     eDate = seconds_to_date(path,end_time_s)
+    #     iDate = seconds_to_date(path,start_time[i])
+    #     fDate = seconds_to_date(path,end_time[i])
+    #     if (sDate.date() <= iDate.date() <= eDate.date()) & (sDate.date() <= fDate.date() <= eDate.date()):
+    #         time_indices += i
+    # time_indices_s = np.where((start_time_s <= start_time) & (start_time <= end_time_s))[0]
+    # time_indices_e = np.where((start_time_s <= end_time) & (end_time <= end_time_s))[0]
+    # time_indices = np.intersect1d(time_indices_s, time_indices_e) # THIS IS NOT EXACTLY EQUIVALENT BECAUSE IN COVERAGE_FREQUENCY_MAP THE .date() IS USED...
+
+    # AB: THIS IS WHAT I WOULD PROPOSE TO DO:
+    time_indices = np.where( ((start_time < end_time_s) & (end_time > start_time_s)))[0]
     start_time = start_time[time_indices]
     end_time = end_time[time_indices]
 
+    # Extracting data (Filtered by time only)
     start_lat1 = (ds.variables['start_lat1'][:])[time_indices]
     start_lat2 = (ds.variables['start_lat2'][:])[time_indices]
     start_lat3 = (ds.variables['start_lat3'][:])[time_indices]
@@ -469,6 +500,7 @@ def load_netcdf(path:str):
     idx2 = (ds.variables['idx2'][:])[time_indices]
     idx3 = (ds.variables['idx3'][:])[time_indices]
     no   = (ds.variables['no'][:])[time_indices]
+    print(len(np.unique(no)))
 
     id_start_lat1 = (ds.variables['id_start_lat1'][:])[time_indices]
     id_start_lat2 = (ds.variables['id_start_lat2'][:])[time_indices]
@@ -478,6 +510,11 @@ def load_netcdf(path:str):
     dudy = (ds.variables['dudy'][:])[time_indices]
     dvdx = (ds.variables['dvdx'][:])[time_indices]
     dvdy = (ds.variables['dvdy'][:])[time_indices]
+
+    min_date = seconds_to_date(path,np.min(start_time))
+    max_date = seconds_to_date(path,np.max(end_time))
+    print(f"Earliest/latest start/end dates of data included in deformation map: {min_date} to {max_date}")
+
 
     # Compressing coordinates into arrays of arrays
     start_lats = np.array([start_lat1, start_lat2, start_lat3])
@@ -526,11 +563,11 @@ def load_netcdf(path:str):
     # Closing dataset
     ds.close()
 
-    return {'start_lats': start_lats, 'start_lons': start_lons, 'end_lats': end_lats, 'end_lons': end_lons, 
-            'div': div, 'shr': shr, 'vrt': vrt, 
-            'start_time': start_time, 'end_time': end_time, 'time_indices': time_indices, 
+    return {'start_lats': start_lats, 'start_lons': start_lons, 'end_lats': end_lats, 'end_lons': end_lons,
+            'div': div, 'shr': shr, 'vrt': vrt,
+            'start_time': start_time, 'end_time': end_time, 'time_indices': time_indices,
             'reftime': reftime, 'icetracker': icetracker, 'timestep': timestep,'tolerance': tolerance,
-            'trackingerror': trackingerror, 
-            'idx1': idx1, 'idx2': idx2, 'idx3': idx3, 'no': no, 
-            'start_id1': id_start_lat1, 'start_id2': id_start_lat2, 'start_id3': id_start_lat3, 
+            'trackingerror': trackingerror,
+            'idx1': idx1, 'idx2': idx2, 'idx3': idx3, 'no': no,
+            'start_id1': id_start_lat1, 'start_id2': id_start_lat2, 'start_id3': id_start_lat3,
             'dudx': dudx, 'dudy': dudy, 'dvdx': dvdx, 'dvdy': dvdy}

--- a/src/SatelliteCoverage/config.py
+++ b/src/SatelliteCoverage/config.py
@@ -79,7 +79,7 @@ def compile_data(raw_paths):
 
         # Updating counter
         i += 1
-        print(f'{i} / {num_files}')
+        # print(f'{i} / {num_files}')
 
     return df
 
@@ -279,6 +279,10 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
                             if fDate > max_date:
                                 max_date = fDate
 
+    # Force interval limit dates to start/end at 00:00:00
+    min_date = min_date.replace(hour=0,minute=0,second=0)
+    max_date = max_date.replace(hour=0,minute=0,second=0)
+    
     # Notifying user of date range change
     if sDate != min_date or eDate != max_date:
         print(f"Start and end dates of data updated to {min_date} and {max_date}")
@@ -429,7 +433,7 @@ def load_netcdf(path:str):
 
     # Indices of data in desired time frame
     time_indices = np.where( (start_time > start_time_s) & (start_time < end_time_s) )[0]
-
+    
     # Extracting data (Filtered by time only)
 
     start_time = start_time[time_indices]

--- a/src/SatelliteCoverage/config.py
+++ b/src/SatelliteCoverage/config.py
@@ -432,10 +432,16 @@ def load_netcdf(path:str):
     end_time = ds.variables['end_time'][:]
 
     # Indices of data in desired time frame
-    time_indices = np.where( (start_time > start_time_s) & (start_time < end_time_s) )[0]
+    # AB: THIS NOW SELECTS ALL PAIRS THAT START OR END DURING THE PLOTTING TIME 
+    #     INTERVAL SPECIFIED IN [Date_options] IN 'options.ini'
+    #     !!!! MAYBE ADD A SECOND FILTER TO KEEP ONLY THOSE THAT HAVE A MINIMUM OF 
+    #     50% OF THEIR DT COVERING THE SELECTED PLOTTING TIME INTERVAL?
+    time_indices_s = np.where( (start_time > start_time_s) & (start_time < end_time_s) )[0]
+    time_indices_e = np.where( (end_time > start_time_s) & (start_time < start_time_s) )[0]
+    time_indices = np.unique(np.append(time_indices_s,time_indices_e))
+    
     
     # Extracting data (Filtered by time only)
-
     start_time = start_time[time_indices]
     end_time = end_time[time_indices]
 

--- a/src/SatelliteCoverage/config.py
+++ b/src/SatelliteCoverage/config.py
@@ -261,9 +261,6 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
                     # Checking if all files from iDate to fDate will be loaded (timestep == '0')
                     if timestep != '0':
                         # Filtering by date range and delta t and appending to the file list
-                        # AB: THIS WAS THE ORIGINAL FILTER:
-                        # if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months:
-                        # AB: THIS IS WHAT I WOULD PROPOSE:
                         if iDate < eDate and fDate > sDate and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months:
                             raw_paths.append(data_path + '/' + filename)
 
@@ -275,8 +272,7 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
 
                     elif timestep == '0':
                         # Filtering by date range only
-                        # AB: NEED TO CORRECT WITH THE SAME FILTER AS ABOVE HERE:
-                        if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and iDate.month not in summer_months:
+                        if iDate < eDate and fDate > sDate and iDate.month not in summer_months:
                             raw_paths.append(data_path + '/' + filename)
 
                             # Updating date tracker
@@ -454,23 +450,6 @@ def load_netcdf(path:str):
     end_time = ds.variables['end_time'][:]
 
     # Indices of data in desired time frame
-    # AB: THIS WAS THE ORIGINAL VERSION:
-    # time_indices = np.where( (start_time > start_time_s) & (start_time < end_time_s) )[0]
-
-    # AB: THIS WOULD CORRESPOND TO WHAT IS DONE COVERAGE FREQUENCY MAP:
-    # time_indices = []
-    # for i in range(len(start_time)):
-    #     sDate = seconds_to_date(path,start_time_s)
-    #     eDate = seconds_to_date(path,end_time_s)
-    #     iDate = seconds_to_date(path,start_time[i])
-    #     fDate = seconds_to_date(path,end_time[i])
-    #     if (sDate.date() <= iDate.date() <= eDate.date()) & (sDate.date() <= fDate.date() <= eDate.date()):
-    #         time_indices += i
-    # time_indices_s = np.where((start_time_s <= start_time) & (start_time <= end_time_s))[0]
-    # time_indices_e = np.where((start_time_s <= end_time) & (end_time <= end_time_s))[0]
-    # time_indices = np.intersect1d(time_indices_s, time_indices_e) # THIS IS NOT EXACTLY EQUIVALENT BECAUSE IN COVERAGE_FREQUENCY_MAP THE .date() IS USED...
-
-    # AB: THIS IS WHAT I WOULD PROPOSE TO DO:
     time_indices = np.where( ((start_time < end_time_s) & (end_time > start_time_s)))[0]
     start_time = start_time[time_indices]
     end_time = end_time[time_indices]
@@ -500,7 +479,6 @@ def load_netcdf(path:str):
     idx2 = (ds.variables['idx2'][:])[time_indices]
     idx3 = (ds.variables['idx3'][:])[time_indices]
     no   = (ds.variables['no'][:])[time_indices]
-    print(len(np.unique(no)))
 
     id_start_lat1 = (ds.variables['id_start_lat1'][:])[time_indices]
     id_start_lat2 = (ds.variables['id_start_lat2'][:])[time_indices]

--- a/src/SatelliteCoverage/coverage_frequency_map.py
+++ b/src/SatelliteCoverage/coverage_frequency_map.py
@@ -34,10 +34,10 @@ def get_map_bins(xy, options=None):
     resolution = float(options['resolution'])
 
     # Upper (u) and lower (l) extents of map_x, map_y (metres)
-    lxextent = -4400000
+    lxextent = -3100000
     uxextent = 2500000
-    uyextent = 3500000
-    lyextent = -2500000
+    uyextent = 2500000
+    lyextent = -1900000
 
     # Grid resolution calculations
     xscale = uxextent - lxextent
@@ -179,7 +179,7 @@ def interval_frequency_histogram2d(interval_list, xbins_map, ybins_map, Date_opt
         # Loads data and converts to x/y for each interval
         interval_df = compile_data(interval_list[i])
 
-            # Skips empty lists
+        # Skips empty lists
         try:
             xy = convert_to_grid(interval_df['lon'], interval_df['lat'])
         except KeyError:
@@ -233,6 +233,7 @@ def interval_frequency_histogram2d(interval_list, xbins_map, ybins_map, Date_opt
     #cax = divider.append_axes("right", size="5%",pad=0.2)
     clb = plt.colorbar(im)#,shrink=0.5
     clb.set_label('% of total period tile has data')
+    clb.set_ticks(np.arange(0, 110, 10))
     clb.set_ticklabels(np.arange(0, 110, 10))
     # plt.axis('scaled')
 

--- a/src/SatelliteCoverage/coverage_frequency_map.py
+++ b/src/SatelliteCoverage/coverage_frequency_map.py
@@ -17,6 +17,7 @@ import cartopy.feature as cfeature
 from matplotlib.colors import Normalize
 import matplotlib as mpl
 import matplotlib.pyplot as plt
+from datetime import datetime
 import numpy as np
 import pandas as pd
 import math
@@ -28,40 +29,16 @@ from config import *
 import warnings
 warnings.filterwarnings("ignore")
 
-# Visualises spatio-temporal coverage on a basemap
-def visualise_coverage_histogram2d(xy, max_date, min_date, timestep):
-    print('--- Plotting heat map ---')
-    """
-    Preamble
-    """
-    proj = ccrs.NorthPolarStereo(central_longitude=0)
+# Generate map x/y bins that will be used to compute frequency at each cell on map
+def get_map_bins(xy, options=None):
+    resolution = float(options['resolution'])
 
-    fig = plt.figure(figsize=(6.5, 5.5), )
-    ax = fig.add_subplot(projection = proj, frameon=False)
-
-    # Timestep calculation
-    date_delta = max_date - min_date
-    delta_hours = date_delta.total_seconds() // 3600
-    length = delta_hours // int(timestep)
-
-    """
-    Terrain
-    """
-    # Upper (u) and lower (l) extents of x, y (metres)
-    lxextent = -3100000
+    # Upper (u) and lower (l) extents of map_x, map_y (metres)
+    lxextent = -4400000
     uxextent = 2500000
-    uyextent = 2500000
-    lyextent = -1900000
-    
-    # Show lat/lon grid
-    ax.gridlines(draw_labels=True)
+    uyextent = 3500000
+    lyextent = -2500000
 
-    # Hide datapoints over land
-    ax.add_feature(cfeature.LAND, zorder=100, edgecolor='k')
-    
-    """
-    Data
-    """
     # Grid resolution calculations
     xscale = uxextent - lxextent
     yscale = uyextent - lyextent
@@ -72,106 +49,42 @@ def visualise_coverage_histogram2d(xy, max_date, min_date, timestep):
     # Extracting x and y coordinates of datapoints (Numpy arrays)
     xi, yj = xy
 
-    # Plotting histogram (cmin=1 to make values = 0 transparent)
-    norm = plt.Normalize(0, int(length))
-    hh = ax.hist2d(xi, yj, bins=(xscale, yscale), cmap='plasma', cmin=1, norm=norm)
+    # Make bins vectors
+    dxi = (np.max(xi)-np.min(xi)) / xscale
+    dyj = (np.max(yj)-np.min(yj)) / yscale
 
-    # Adding colourbar (hh[3] normalizes the colourbar)
-    cbar = fig.colorbar(hh[3], ax=ax)
-    cbar.set_label(f'% of total period tile has data')
-    cbar.set_ticklabels(np.arange(0, 110, 10))
-    cbar.set_ticks(np.linspace(0, int(length), num=11))
+    xbins_out = np.arange(np.min(xi),np.max(xi)+dxi,dxi)
+    ybins_out = np.arange(np.min(yj),np.max(yj)+dyj,dyj)
 
-    """
-    Extraneous
-    """
-    # Max and min dates for title and file name (_str)
-    max_date_str = max_date.strftime("%Y%m%d")
-    min_date_str = min_date.strftime("%Y%m%d")
-    max_date = max_date.strftime("%x")
-    min_date = min_date.strftime("%x")
-
-    # if/elif for title creation, for grammatical correctness
-    if timestep != '0':
-        ax.set_title(f'{tracker}, {min_date} to {max_date}, {timestep} \u00B1 {tolerance} hours, {resolution} km resolution')
-
-    elif timestep == '0':
-        ax.set_title(f'{tracker}, {min_date} to {max_date} encompassing all time intervals')
-
-    # Saving figure as YYYYMMDD_YYYYMMDD_deltat_tolerance_resolution_'res'_tracker_freq.png
-    prefix = tracker + '_' + min_date_str + '_' + max_date_str + '_dt' + timestep + '_tol' + tolerance + '_res' + str(int(resolution)) 
-
-    # Set a directory to store figures
-    figsPath =  output + '/' + '/figs/'
-
-    # Create directory if it doesn't exist
-    os.makedirs(figsPath, exist_ok=True)
-
-    plt.savefig(figsPath + prefix + '_' + 'freq.png')
-
-    print(f'Saved as {prefix}_freq.png')
-
-    return hh[1], hh[2]
+    return xbins_out, ybins_out
 
 # Returns histogram of coverage representing the arctic ocean
-def coverage_histogram2d(xy, xbins, ybins):
+def coverage_histogram2d(xy, xbins_map, ybins_map):
     """
     Returns a 2D numpy array representing grid cells with or without data
     (1 or 0).
 
     INPUTS:
     xy -- Array of tuples containing x and y coordinates of data {numpy array}
+    xbins_map, ybins_map -- Map bins for frequency histogram
 
     OUTPUTS:
     H -- 2D numpy array representing polar stereographic grid with 1s and 0s,
          representing the presence of lack of data. {numpy array}
     """
 
-    """
-    Preamble
-    """
-    # Reading config & preamble
-    config = read_config()
-
-    IO = config['IO']
-    Date_options = config['Date_options']
-    options = config['options']
-    meta = config['Metadata']
-
-    resolution = float(options['resolution'])
-
-    proj = ccrs.NorthPolarStereo(central_longitude=0)
-
-    fig = plt.figure(figsize=(6.5, 5.5), )
-    ax = fig.add_subplot(projection = proj, frameon=False)
-
-    """
-    Data
-    """
-    # Upper (u) and lower (l) extents of histogram grid (metres)
-    lxextent = -3100000
-    uxextent = 2500000
-    uyextent = 2500000
-    lyextent = -1900000
-
-    # Grid resolution calculations (x,yscale final values in *resolution* km)
-    xscale = uxextent - lxextent
-    yscale = uyextent - lyextent
-
-    xscale = math.floor(xscale / (1000 * resolution))
-    yscale = math.floor(yscale / (1000 * resolution))
-
     # Extracting x and y coordinates of datapoints (numpy arrays)
     xi, yj = xy
 
     # Plotting histogram (H) and converting bin values to 0 or 1 range=[[lxextent,uxextent], [lyextent,uyextent]]
-    H, xbins, ybins = np.histogram2d(xi, yj, bins=(xbins, ybins))
+    H, _, _ = np.histogram2d(xi, yj, bins=(xbins_map, ybins_map))
     H[H>1] = 1
 
     return H
 
+
 # Plots timeseries of spatial coverage
-def coverage_timeseries(interval_list, resolution, date_pairs):
+def coverage_timeseries(interval_list, resolution, date_pairs, xbins_map, ybins_map):
     """
     Plots a time series of the area coverage (in % of the Arctic ocean) for a given list of lists containing
     data file paths [interval_list], where each list of files defines a user-set interval (i.e. interval of 72hrs)
@@ -210,7 +123,7 @@ def coverage_timeseries(interval_list, resolution, date_pairs):
             continue
 
         # Generates histogram (2d np array)
-        histogram = coverage_histogram2d(xy, xbins, ybins)
+        histogram = coverage_histogram2d(xy, xbins_map, ybins_map)
 
         # Computing area of arctic ocean covered
         covered_area = len((np.flatnonzero(histogram)))
@@ -240,17 +153,19 @@ def coverage_timeseries(interval_list, resolution, date_pairs):
 
     print('Saved as ' + figsPath)
 
+
 # Visualises coverage as a heatmap, split between user-set intervals
-def interval_frequency_histogram2d(interval_list):
+def interval_frequency_histogram2d(interval_list, xbins_map, ybins_map, Date_options=None):
     """
     Plots a heatmap showing data availaibility (in % of time intervals covered) in a specified range of times.
 
     INPUTS:
     interval_list -- List of lists, with each sub-list (n-th) containing the paths to data files contained within
                      the n-th interval.
+    Date_options --
 
     OUTPUTS:
-    Heatmap image (.png) in user-set output folder, with file name 'TRACKER_STARTDATE_to_ENDDATE_DELTAt+-TOLERANCE_
+    Heatmap image (.png) in user-set output folder, with file name 'STARTDATE_to_ENDDATE_DELTAt+-TOLERANCE_
     hrs_RESOLUTION_km_INTERVAL_hrs"
 
     """
@@ -272,22 +187,23 @@ def interval_frequency_histogram2d(interval_list):
             continue
 
         # Generates histogram (2D numpy array)
-        histogram = coverage_histogram2d(xy, xbins, ybins)
-        histogram[histogram>0.0] = 1.0
+        histogram = coverage_histogram2d(xy, xbins_map, ybins_map)
+        histogram[histogram > 0.0] = 1.0
         # Changing size of total histogram (only on first run)
         if i == 0:
             H.resize(histogram.shape)
+
 
         # Adding interval-specific histogram to total histogram
         H = H + histogram
 
     # Transposing histogram for plotting
     H = H.T
+    H[H == 0] = np.nan
 
     """
     Land and projection
     """
-
     proj = ccrs.NorthPolarStereo(central_longitude=0)
 
     fig = plt.figure(figsize=(6.5, 5.5), )
@@ -296,13 +212,15 @@ def interval_frequency_histogram2d(interval_list):
     out_proj = pyproj.Proj(init='epsg:4326')
     in_proj = pyproj.Proj('+proj=stere +lat_0=90 +lat_ts=70 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ', preserve_units=True)
 
-    xx, yy = np.meshgrid(xbins, ybins)
+    xx, yy = np.meshgrid(xbins_map, ybins_map)
 
     binslon,binslat = pyproj.transform(in_proj,out_proj,xx,yy)
     H[H==0.0] = np.nan
     H = H*100.0
-    print(binslon.shape,binslat.shape,H.shape)
 
+    """
+    Plot Data
+    """
     cmap1 = mpl.colormaps['plasma']
     cmap1.set_bad('w')
 
@@ -314,14 +232,9 @@ def interval_frequency_histogram2d(interval_list):
     #divider = make_axes_locatable(ax)
     #cax = divider.append_axes("right", size="5%",pad=0.2)
     clb = plt.colorbar(im)#,shrink=0.5
-    """
-    Terrain
-    """
-    # Upper (u) and lower (l) extents of x, y (metres)
-    lxextent = -3100000
-    uxextent = 2500000
-    uyextent = 2500000
-    lyextent = -1900000
+    clb.set_label('% of total period tile has data')
+    clb.set_ticklabels(np.arange(0, 110, 10))
+    # plt.axis('scaled')
 
     # Show lat/lon grid
     ax.gridlines()
@@ -329,23 +242,22 @@ def interval_frequency_histogram2d(interval_list):
     # Hide datapoints over land
     ax.add_feature(cfeature.LAND, zorder=100, edgecolor='k')
 
-    """
-    Data
-    """
-    # Grid resolution calculations
-#    xscale = uxextent - lxextent
-#    yscale = uyextent - lyextent
-
-#    xscale = math.floor(xscale / (1000 * int(resolution)))
-#    yscale = math.floor(yscale / (1000 * int(resolution)))
-
-#    length = len(interval_list)
-
     # Converting dates for title and file name purposes
-    max_date_title = str(max_date.strftime('%Y')) + '-' + str(max_date.strftime('%m')) + '-' + str(max_date.strftime('%d'))
-    min_date_title = str(min_date.strftime('%Y')) + '-' + str(min_date.strftime('%m')) + '-' + str(min_date.strftime('%d'))
-    max_date_str = max_date.strftime("%Y%m%d")
-    min_date_str = min_date.strftime("%Y%m%d")
+    start_year  = str(Date_options['start_year'])
+    start_month = str(Date_options['start_month'])
+    start_day   = str(Date_options['start_day'])
+    end_year    = str(Date_options['end_year'])
+    end_month   = str(Date_options['end_month'])
+    end_day     = str(Date_options['end_day'])
+
+    # Concatenate start and end dates
+    sDate = datetime.strptime(start_year + start_month + start_day, '%Y%m%d')
+    eDate = datetime.strptime(end_year + end_month + end_day, '%Y%m%d')
+
+    eDate_title = end_year + '-' + end_month + '-' + end_day
+    sDate_title = start_year + '-' + start_month + '-' + start_day
+    eDate_str = eDate.strftime("%Y%m%d")
+    sDate_str = sDate.strftime("%Y%m%d")
 
     # Set a directory to store figures
     figsPath =  output + '/' + '/figs/'
@@ -355,17 +267,16 @@ def interval_frequency_histogram2d(interval_list):
 
     # if/elif for title creation, for grammatical correctness
     if timestep != '0':
-        ax.set_title(f'Percent coverage ({interval}h intervals), {tracker}, \n {min_date_title} - {max_date_title}, {timestep} \u00B1 {tolerance} h pairs')
+        ax.set_title(f'Percent coverage ({interval}h intervals), {tracker}, \n {sDate_title} - {eDate_title}, {timestep} \u00B1 {tolerance} h pairs')
 
     elif timestep == '0':
-        ax.set_title(f'{tracker}, {min_date} to {max_date}, all timesteps, {resolution} km, {interval} hr intervals')
+        ax.set_title(f'{tracker}, {sDate_title} to {eDate_title}, all timesteps, {resolution} km, {interval} hr intervals')
 
     # Saving figure as YYYYMMDD_YYYYMMDD_timestep_tolerance_resolution_'res'_tracker_freq.png
-    prefix = tracker + '_'+ min_date_str + '_' + max_date_str + '_dt' + timestep + '_tol' + tolerance + '_res' + resolution + '_' + interval
+    prefix = tracker + '_'+ sDate_str + '_' + eDate_str + '_dt' + timestep + '_tol' + tolerance + '_res' + resolution + '_' + interval
     plt.savefig(figsPath + prefix + '_' + 'intervalfreq.png')
 
     print(f'Saved as {prefix}_intervalfreq.png')
-
 
 
 
@@ -398,11 +309,12 @@ if __name__ == '__main__':
     interval = options['interval']
 
     # Fetching filter information
-    raw_list, max_date, min_date = filter_data(Date_options = Date_options, IO = IO, Metadata = meta)
+    raw_list = filter_data(Date_options = Date_options, IO = IO, Metadata = meta)
+    print(len(raw_list))
 
     # Dividing data into intervals if the user desires
     if coverage_frequency['visualise_timeseries'] == 'True' or coverage_frequency['visualise_interval'] == True:
-        interval_list, date_pairs = divide_intervals(raw_list, max_date, min_date, interval)
+        interval_list, date_pairs = divide_intervals(raw_list, Date_options, options)
 
     # Compiling master dataframe
     df = compile_data(raw_list)
@@ -411,14 +323,13 @@ if __name__ == '__main__':
     xy = convert_to_grid(df['lon'], df['lat'])
 
     # Plotting coverage heat map
-    xbins, ybins = visualise_coverage_histogram2d(xy, max_date, min_date, timestep)
+    # xbins, ybins = visualise_coverage_histogram2d(xy, Date_options)
+    xbins, ybins = get_map_bins(xy, options)
 
     if coverage_frequency['visualise_timeseries'] == 'True':
-
-        # Plotting time series
-        coverage_timeseries(interval_list, resolution, date_pairs)
+        # Plotting time series of coverage in % of total Arctic Ocean area
+        coverage_timeseries(interval_list, resolution, date_pairs, xbins, ybins)
 
     if coverage_frequency['visualise_interval'] == 'True':
-
-        # Plotting interval heat map
-        interval_frequency_histogram2d(interval_list)
+        # Plotting coverage heat map in % of intervals with data
+        interval_frequency_histogram2d(interval_list, xbins, ybins, Date_options)

--- a/src/SatelliteCoverage/netcdf_tools.py
+++ b/src/SatelliteCoverage/netcdf_tools.py
@@ -40,7 +40,7 @@ def plot_start_end_points(path:str):
 
     OUTPUTS:
     None -- Saves plot to the output directory
-    
+
     """
     print('--- Plotting start and end points ---')
 
@@ -71,7 +71,7 @@ def plot_start_end_points(path:str):
     lyextent = -2500000
 
     ax.set_extent((lxextent, uxextent, uyextent, lyextent), ccrs.NorthPolarStereo())
-    
+
     # Show lat/lon grid and coastlines
     ax.gridlines(draw_labels=True)
     ax.coastlines()
@@ -89,7 +89,7 @@ def plot_start_end_points(path:str):
         # Converting start/end lat/lons to x/y (North pole stereographic)
         start_x, start_y = convert_to_grid(start_lons[i], start_lats[i])
         end_x, end_y = convert_to_grid(end_lons[i], end_lats[i])
-        
+
         # Plotting start points (Blue)
         ax.scatter(start_x, start_y, color = 'blue', s = 0.01)
 
@@ -106,7 +106,7 @@ def plot_start_end_points(path:str):
     os.makedirs(figsPath, exist_ok=True)
 
     # Set prefix for filename
-    prefix = satellite + '_' + start_year + start_month + start_day + '_' + end_year + end_month + end_day + '_dt' + str(timestep) + '_tol' + str(tolerance) 
+    prefix = satellite + '_' + start_year + start_month + start_day + '_' + end_year + end_month + end_day + '_dt' + str(timestep) + '_tol' + str(tolerance)
 
     # Full path of figure
     fig_path = figsPath + prefix + '_start_end_points.png'
@@ -121,7 +121,7 @@ def plot_start_end_points(path:str):
 def recreate_coordinates(start_lat1, start_lat2, start_lat3, start_lon1, start_lon2, start_lon3, start_id1, start_id2, start_id3):
     """
     This function takes in a list of start lats/lons and corresponding start lat/lon IDs (triangle vertices)
-    and outputs corresponding, larger lists of start lats/lons (with 0s in some indices) that reflect the 
+    and outputs corresponding, larger lists of start lats/lons (with 0s in some indices) that reflect the
     coordinates' placement in the original data files for use with ax.tripcolor
 
     INPUTS:
@@ -141,7 +141,7 @@ def recreate_coordinates(start_lat1, start_lat2, start_lat3, start_lon1, start_l
     # Skipping blank data files
     if len(start_ids) == 0:
         return 0, 0
-    
+
     # Initializing new lists of coordinates
     new_lon, new_lat = ([np.nan] * (max(start_ids) + 1) for i in range(2))
 
@@ -149,17 +149,17 @@ def recreate_coordinates(start_lat1, start_lat2, start_lat3, start_lon1, start_l
         new_lat[start_id1[i]] = (start_lat1[i])
         new_lat[start_id2[i]] = (start_lat2[i])
         new_lat[start_id3[i]] = (start_lat3[i])
-    
+
     for i in range(len(start_lon1)):
         new_lon[start_id1[i]] = start_lon1[i]
         new_lon[start_id2[i]] = start_lon2[i]
         new_lon[start_id3[i]] = start_lon3[i]
-        
+
     return new_lat, new_lon
-    
+
 def plot_deformations(path:str):
     """
-    This function plots deformations from a netCDF file using matplotlib's ax.tripcolor. 
+    This function plots deformations from a netCDF file using matplotlib's ax.tripcolor.
     The function assumes that the netCDF was generated from src/SeaIceDeformation's M01_d03_compute_deformations.py.
 
     INUPTS:
@@ -200,38 +200,34 @@ def plot_deformations(path:str):
     Plotting
     """
 
-    # Obtaining start index of data
-    min_no = np.nanmin(data['no']) # Minimum (smallest) ID number
-    min_index = np.nanmin(np.where(data['no'] == min_no)) # This value will be updated for each triangle
-
     print('--- Creating sea-ice deformation figures ---')
 
     # Iterating over all files (Unique triangulations)
-    for i in range(len(set(data['no']))):
-        # Here the file indice is zero-indexed, so the first file has the indice 0, regardless of its ID
+    for i in np.unique(data['no']):
 
-        # Obtaining number of rows to iterate over
-        file_length = np.count_nonzero(data['no'] == i + min_no)
+        # Obtaining number of rows corresponding to triangles in given file that will be iterated over
+        file_length = np.count_nonzero(data['no'] == i)
 
         # Setting maximum index
-        max_index = min_index + file_length
+        min_index = np.where(data['no'] == i)[0][0]
+        max_index = np.where(data['no'] == i)[0][-1]+1
+        print(i,file_length,min_index,max_index)
 
         # Arranging triangle vertices in array for use in ax.tripcolor
-        triangles = np.stack((data['idx1'][min_index:max_index], data['idx2'][min_index:max_index], 
+        triangles = np.stack((data['idx1'][min_index:max_index], data['idx2'][min_index:max_index],
                     data['idx3'][min_index:max_index]), axis=-1)
 
         # Filtering data range to that of the current "file"
-
         start_lat1_temp, start_lat2_temp, start_lat3_temp = data['start_lats'][0][min_index:max_index], \
             data['start_lats'][1][min_index:max_index], data['start_lats'][2][min_index:max_index]
-        
+
         start_lon1_temp, start_lon2_temp, start_lon3_temp = data['start_lons'][0][min_index:max_index], \
             data['start_lons'][1][min_index:max_index], data['start_lons'][2][min_index:max_index]
 
-        start_lat, start_lon = recreate_coordinates(start_lat1_temp, start_lat2_temp, start_lat3_temp, 
-                                                        start_lon1_temp, start_lon2_temp, start_lon3_temp, 
+        start_lat, start_lon = recreate_coordinates(start_lat1_temp, start_lat2_temp, start_lat3_temp,
+                                                        start_lon1_temp, start_lon2_temp, start_lon3_temp,
                                                         data['start_id1'][min_index:max_index],
-                                                        data['start_id2'][min_index:max_index], 
+                                                        data['start_id2'][min_index:max_index],
                                                         data['start_id3'][min_index:max_index])
 
         # Extracting deformation data
@@ -245,8 +241,6 @@ def plot_deformations(path:str):
             cb_shr = ax_shr.tripcolor(start_lon, start_lat, triangles, transform=trans, facecolors=shr_colours, cmap='plasma', vmin=0, vmax=0.1)
             cb_vrt = ax_vrt.tripcolor(start_lon, start_lat, triangles, transform=trans, facecolors=vrt_colours, cmap='coolwarm', vmin=-0.1, vmax=0.1)
 
-        # Updating minimum index
-        min_index = max_index
 
     # Create a list of colorbars and titles to be iterated over
     cb_list = [cb_div, cb_shr, cb_vrt]
@@ -258,7 +252,7 @@ def plot_deformations(path:str):
         plt.colorbar(cb, ax=ax)
 
         # Add a title
-        ax.set_title(title + '\n' + start_year + '-' + start_month + '-' + start_day + ' to ' + 
+        ax.set_title(title + '\n' + start_year + '-' + start_month + '-' + start_day + ' to ' +
                         end_year + '-' + end_month + '-' + end_day + ', ' + timestep + 'hr')
 
         # Add gridlines
@@ -274,21 +268,21 @@ def plot_deformations(path:str):
 
     # Set a directory to store figures for the current experiment
     figsPath =  output_folder + '/' + '/figs/'
-        
+
     # Create the directory if it does not exist already
     os.makedirs(figsPath, exist_ok=True)
 
     # Create a prefix for the figure filenames
     prefix = data['icetracker'] + '_' + start_year + start_month + start_day + '_' + end_year + end_month + end_day + '_dt' + str(timestep) + '_tol' + str(tolerance)
-        
+
     # Create the figure filenames
     div_path   = figsPath + prefix + '_div.png'
     shr_path = figsPath + prefix + '_shr.png'
     rot_path   = figsPath + prefix + '_rot.png'
 
-        
+
     for fig, fig_path in zip([fig_div, fig_shr, fig_vrt], [div_path, shr_path, rot_path]):
-            
+
         # Check if the figures already exist. If they do, delete them.
         if os.path.isfile(fig_path):
             os.remove(fig_path)
@@ -296,135 +290,6 @@ def plot_deformations(path:str):
         # Save the new figures
         fig.savefig(fig_path, bbox_inches='tight', dpi=600)
 
-def write_netcdf(path:str, output_folder:str):
-    # !!! THIS FUNCTION SEEMS LIKE IT WRITES THE EXACT SAME NETCDF FILE AS THE ONE IT OPENS...
-    # !!! IT DOES NOT SEEM NECESSARY.... KILL?
-    
-    # Load data
-    data = load_netcdf(path)
-
-    '''
-    _________________________________________________________________________________________
-    WRITE ALL RESULTS COMBINED TO A NETCDF FILE
-    '''
-    # Find absolute path in which the output netcdf file is to be stored
-    output_path = output_folder + '/' + start_year + start_month + start_day + '_' + end_year + end_month + end_day + '_dt' + timestep + '_filtered_dx.nc'
-
-    # Create a directory to store the output netcdf file if it does not exist already
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
-
-    # Create an output netcdf file and dataset
-    output_ds = Dataset(output_path, 'w', format = 'NETCDF4')
-    
-    # Add metadata
-    output_ds.iceTracker    = data['icetracker']
-    output_ds.referenceTime = data['reftime']
-    output_ds.trackingError = data['trackingerror']
-
-    # Create x array to store output data
-    x = output_ds.createDimension('x', len(data['start_time']))
-        
-    # Create variables for netcdf data set
-    start_time = output_ds.createVariable('start_time', 'u4', 'x') # Start and end times
-    end_time   = output_ds.createVariable('end_time', 'u4', 'x')
-    
-    start_lat1 = output_ds.createVariable('start_lat1', 'f8', 'x') # Starting Lat/Lon triangle vertices
-    start_lat2 = output_ds.createVariable('start_lat2', 'f8', 'x')
-    start_lat3 = output_ds.createVariable('start_lat3', 'f8', 'x')
-    start_lon1 = output_ds.createVariable('start_lon1', 'f8', 'x')
-    start_lon2 = output_ds.createVariable('start_lon2', 'f8', 'x')
-    start_lon3 = output_ds.createVariable('start_lon3', 'f8', 'x')
-    
-    end_lat1   = output_ds.createVariable('end_lat1', 'f8', 'x') # Ending Lat/Lon triangle vertices
-    end_lat2   = output_ds.createVariable('end_lat2', 'f8', 'x')
-    end_lat3   = output_ds.createVariable('end_lat3', 'f8', 'x')
-    end_lon1   = output_ds.createVariable('end_lon1', 'f8', 'x')
-    end_lon2   = output_ds.createVariable('end_lon2', 'f8', 'x')
-    end_lon3   = output_ds.createVariable('end_lon3', 'f8', 'x')
-    
-    d          = output_ds.createVariable('div', 'f8', 'x') # Divergence and shear strain and vorticity rates
-    s          = output_ds.createVariable('shr', 'f8', 'x')
-    v          = output_ds.createVariable('vrt', 'f8', 'x')
-
-    id1        = output_ds.createVariable('idx1', 'u4', 'x') # Triangle vertices 
-    id2        = output_ds.createVariable('idx2', 'u4', 'x')
-    id3        = output_ds.createVariable('idx3', 'u4', 'x')
-    idtri      = output_ds.createVariable('no', 'u4', 'x')
-
-    id_start_lat1 = output_ds.createVariable('id_start_lat1', 'u4', 'x') # Original coordinate indices
-    id_start_lat2 = output_ds.createVariable('id_start_lat2', 'u4', 'x')
-    id_start_lat3 = output_ds.createVariable('id_start_lat3', 'u4', 'x')
-
-    dux        = output_ds.createVariable('dudx', 'f8', 'x') # Strain rates
-    duy        = output_ds.createVariable('dudy', 'f8', 'x')
-    dvx        = output_ds.createVariable('dvdx', 'f8', 'x')
-    dvy        = output_ds.createVariable('dvdy', 'f8', 'x')
-
-    # Specify units for each variable
-    start_time.units = 'seconds since the reference time'
-    end_time.units   = 'seconds since the reference time'
-    
-    start_lat1.units = 'degrees North'
-    start_lat2.units = 'degrees North'
-    start_lat3.units = 'degrees North'
-    start_lon1.units = 'degrees East'
-    start_lon2.units = 'degrees East'
-    start_lon3.units = 'degrees East'
-    
-    end_lat1.units   = 'degrees North'
-    end_lat2.units   = 'degrees North'
-    end_lat3.units   = 'degrees North'
-    end_lon1.units   = 'degrees East'
-    end_lon2.units   = 'degrees East'
-    end_lon3.units   = 'degrees East'
-
-    d.units          = '1/days'
-    s.units          = '1/days'
-    v.units          = '1/days'
-
-    dux.units        = '1/days'
-    duy.units        = '1/days'
-    dvx.units        = '1/days'
-    dvy.units        = '1/days'
-
-    # Attribute data arrays to each variable
-    start_time[:] = data['start_time']
-    end_time[:]   = data['end_time']
-    
-    start_lat1[:] = data['start_lats'][0]
-    start_lat2[:] = data['start_lats'][1]
-    start_lat3[:] = data['start_lats'][2]
-    start_lon1[:] = data['start_lons'][0]
-    start_lon2[:] = data['start_lons'][1]
-    start_lon3[:] = data['start_lons'][2]
-    
-    end_lat1[:]   = data['end_lats'][0]
-    end_lat2[:]   = data['end_lats'][1]
-    end_lat3[:]   = data['end_lats'][2]
-    end_lon1[:]   = data['end_lons'][0]
-    end_lon2[:]   = data['end_lons'][1]
-    end_lon3[:]   = data['end_lons'][2]
-
-    d[:]          = data['div']
-    s[:]          = data['shr']
-    v[:]          = data['vrt']
-
-    id1[:]        = data['idx1']
-    id2[:]        = data['idx2']
-    id3[:]        = data['idx3']
-    idtri[:]      = data['no']
-
-    id_start_lat1[:] = data['start_id1']
-    id_start_lat2[:] = data['start_id2']
-    id_start_lat3[:] = data['start_id3']
-
-    dux[:]       = data['dudx']
-    duy[:]       = data['dudy']
-    dvx[:]       = data['dvdx']
-    dvy[:]       = data['dvdy']
-
-    # Close dataset
-    output_ds.close()
 
 if __name__ == '__main__':
     # Reading config
@@ -461,6 +326,3 @@ if __name__ == '__main__':
 
     if netcdf_tools['plot_deformation'] == 'True':
         plot_deformations(path)
-
-    # if netcdf_tools['write_netcdf'] == 'True':
-    #     write_netcdf(path, output_folder)

--- a/src/SatelliteCoverage/options.ini
+++ b/src/SatelliteCoverage/options.ini
@@ -1,6 +1,6 @@
 # Author: Lekima Yakuden
 # GitHub: LekiYak
-# 
+#
 # ----------------------------------
 # [IO]
 #   data_folder:    Absolute path to directory containing data files {str}
@@ -37,7 +37,7 @@
 #
 #   resolution:     Resolution of heatmap grid in km (per side). i.e.
 #                   resolution = 10 will plot the heatmap with 10x10 km grid cells. {float}
-#   
+#
 #   area_filter:    Boolean to turn the area filtering function on/off {bool}
 #
 #   centre_lat:     Latitude of centre of area filter {float}
@@ -55,32 +55,30 @@
 #   plot_start_end_points:  Boolean to turn the start/end point visualisation on/off {bool}
 #
 #   plot_deformation:       Boolean to turn the deformation visualisation on/off {bool}
-#
-#   write_netcdf:           Boolean to turn the netcdf writing on/off {bool}
 
 
 [IO]
-data_folder   = /pathtodata/
-output_folder = /outputfolder/
-netcdf_path   = /netcdfpath.nc
+data_folder   = /storage2/common/S1_RCM_tracked_pairs/
+output_folder = /storage2/amelie/ice-tracker-deformations/outputs/
+netcdf_path   = /storage2/common/S1_RCM_datasets/RCMS1SID_20171001_20220331_dt24_tol8_dx.nc
 
 [Metadata]
-ice_tracker = S1
+ice_tracker = RCMS1
 
 [Date_options]
-start_year  = 2020
-start_month = 11
-start_day   = 01
+start_year  = 2019
+start_month = 01
+start_day   = 12
 
-end_year    = 2020
-end_month   = 12
-end_day     = 31
+end_year    = 2019
+end_month   = 01
+end_day     = 14
 
-timestep    = 72
-tolerance   = 20
+timestep    = 24
+tolerance   = 8
 
 [options]
-interval    = 72
+interval    = 24
 resolution  = 10
 
 area_filter = False
@@ -94,6 +92,5 @@ visualise_timeseries = True
 visualise_interval   = True
 
 [netcdf_tools]
-plot_start_end_points = True
+plot_start_end_points = False
 plot_deformation      = True
-write_netcdf          = False

--- a/src/SeaIceDeformation/config.py
+++ b/src/SeaIceDeformation/config.py
@@ -146,7 +146,7 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
                     # Checking if all files from iDate to fDate will be loaded (timestep == '0')
                     if timestep != '0':
                         # Filtering by date range and delta t and appending to the file list
-                        if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months:
+                        if iDate < eDate and fDate > sDate and lower_timestep <= (fDate-iDate) <= upper_timestep and iDate.month not in summer_months:
                             raw_paths.append(data_path + '/' + filename)
 
                             # Updating date tracker
@@ -157,7 +157,7 @@ def filter_data(Date_options = None, IO = None, Metadata = None):
 
                     elif timestep == '0':
                         # Filtering by date range only
-                        if sDate.date() <= iDate.date() <= eDate.date() and sDate.date() <= fDate.date() <= eDate.date() and iDate.month not in summer_months:
+                        if iDate < eDate and fDate > sDate and iDate.month not in summer_months:
                             raw_paths.append(data_path + '/' + filename)
 
                             # Updating date tracker

--- a/src/SeaIceDeformation/visualise_deformation.py
+++ b/src/SeaIceDeformation/visualise_deformation.py
@@ -171,7 +171,7 @@ def visualise_deformations():
                 os.remove(fig_path)
 
             # Save the new figures
-            fig.savefig(fig_path, bbox_inches='tight')
+            fig.savefig(fig_path, bbox_inches='tight', dpi=600)
 
         plt.show()
 


### PR DESCRIPTION
In SatelliteCoverage: 
- Changed start/end dates of interval used to compute the coverage frequency map to be those defined by the user (instead of those from the earliest/latest start/end dates of available files). 
- Cleaned some unused/unnecessary routines (e.g. 'visualise_coverage_histogram2d' and 'write_netcdf')
- Made separate routine to generate map bins for frequency map histogram so that they are now defined once.
- Fixed problem with iterating on the different files 'no' in the netcdf plotting routine.
- Starting debugging why the number of raw files used to make the frequency map with 'coverage_frequency_map' is not the same as the number of different file 'no' used from the netcdf to plot deformations for the same interval. But this is a work in progress... I still don't get the same numbers, but at least both plots say they have the same earliest/latest dates included.