### PR TITLE
Improving time series of coverage 

### DIFF
--- a/src/SatelliteCoverage/coverage_frequency_map.py
+++ b/src/SatelliteCoverage/coverage_frequency_map.py
@@ -75,7 +75,7 @@ def coverage_histogram2d(xy, xbins_map, ybins_map):
 
 
 # Plots timeseries of spatial coverage
-def coverage_timeseries(interval_list, date_pairs, xbins_map, ybins_map, config=None, percentage=False, ref_lat=0):
+def coverage_timeseries(interval_list, date_pairs, xbins_map, ybins_map, config=None):
     """
     Plots a time series of the area coverage (in % of the Arctic ocean) for a given list of lists containing
     data file paths [interval_list], where each list of files defines a user-set interval (i.e. interval of 72hrs)
@@ -95,6 +95,8 @@ def coverage_timeseries(interval_list, date_pairs, xbins_map, ybins_map, config=
     """
     print('--- Plotting coverage time series ---')
 
+    percentage = stb(config['options']['percentage'])
+    ref_lat = float(config['options']['ref_lat'])
     resolution = config['options']['resolution']
     interval = config['options']['interval']
 
@@ -366,7 +368,7 @@ if __name__ == '__main__':
             # Plotting time series of coverage in % of total ocean area above
             # a given 'ref_lat', or of covered area in km^2 above a 'ref_lat'
             # Note: if 'ref_lat' is equal to zero, it takes all available data.
-            coverage_timeseries(interval_list, date_pairs, xbins, ybins, config=config, percentage=True, ref_lat=70)
+            coverage_timeseries(interval_list, date_pairs, xbins, ybins, config=config)
 
         if viz_cf:
             # Plotting coverage heat map in % of intervals with data

--- a/src/SatelliteCoverage/coverage_frequency_map.py
+++ b/src/SatelliteCoverage/coverage_frequency_map.py
@@ -105,6 +105,7 @@ def coverage_timeseries(interval_list, date_pairs, xbins_map, ybins_map, config=
     land_10m = cfeature.NaturalEarthFeature('physical', 'land', '10m')
     land_polygons = list(land_10m.geometries())
 
+    # !!!!!!!!! CHANGE THIS FOR CONVERT_TO/FROM_GRID FUNCTION....!!!!!!!!!!!!!
     out_proj = pyproj.Proj(init='epsg:4326')
     in_proj = pyproj.Proj('+proj=stere +lat_0=90 +lat_ts=70 +lon_0=0 +k=1 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs ', preserve_units=True)
     dxi = (1000*float(resolution))
@@ -365,7 +366,7 @@ if __name__ == '__main__':
             # Plotting time series of coverage in % of total ocean area above
             # a given 'ref_lat', or of covered area in km^2 above a 'ref_lat'
             # Note: if 'ref_lat' is equal to zero, it takes all available data.
-            coverage_timeseries(interval_list, date_pairs, xbins, ybins, config=config, percentage=False, ref_lat=0)
+            coverage_timeseries(interval_list, date_pairs, xbins, ybins, config=config, percentage=True, ref_lat=70)
 
         if viz_cf:
             # Plotting coverage heat map in % of intervals with data

--- a/src/SatelliteCoverage/options.def
+++ b/src/SatelliteCoverage/options.def
@@ -10,7 +10,7 @@
 #   netcdf_path:    Absolute path to netCDF file {str}
 #
 # [meta]
-#   ice_tracker:    Name of satellite(s) {str}
+#   icetracker:    Name of satellite(s) {str}
 #
 # [options]
 #   start_year:     Start year of analysis {int}

--- a/src/SatelliteCoverage/options.def
+++ b/src/SatelliteCoverage/options.def
@@ -84,6 +84,9 @@ tolerance   = 8
 interval    = 24
 resolution  = 20
 
+percentage  = False
+ref_lat = 70
+
 area_filter = False
 centre_lat  = 71
 centre_lon  = -160

--- a/src/SatelliteCoverage/options.def
+++ b/src/SatelliteCoverage/options.def
@@ -10,7 +10,7 @@
 #   netcdf_path:    Absolute path to netCDF file {str}
 #
 # [meta]
-#   icetracker:    Name of satellite(s) {str}
+#   ice_tracker:    Name of satellite(s) {str}
 #
 # [options]
 #   start_year:     Start year of analysis {int}
@@ -58,31 +58,33 @@
 
 
 [IO]
-data_folder = /storage/dringeisen/S1_RCM_tracked_pairs/
-output_folder = /storage/dringeisen/S1_RCM_tracked_pairs/outputs/
-netcdf_path   = /storage/dringeisen/S1_RCM_tracked_pairs/outputs/TESTING_dringeisen/05_output/RCMS1SID_20200301_20200331_dt72_tol5_dx.nc
-exp = TESTING_dringeisen
+data_folder   = /storage2/common/S1_RCM_tracked_pairs/
+output_folder = /storage2/amelie/ice-tracker-deformations/outputs/
+#netcdf_path   = /storage2/common/S1_RCM_datasets/RCMS1SID_20171001_20220331_dt12_tol4_dx.nc
+netcdf_path   = /storage2/common/S1_RCM_datasets/RCMS1SID_20171001_20220331_dt24_tol8_dx.nc
+#netcdf_path   = /storage2/common/S1_RCM_datasets/RCMS1SID_20171001_20220331_dt72_tol24_dx.nc
+exp =
 
 [Metadata]
 icetracker = RCMS1
 
 [Date_options]
-start_year  = 2020
+start_year  = 2021
 start_month = 03
-start_day   = 01
+start_day   = 10
 
-end_year    = 2020
+end_year    = 2021
 end_month   = 03
-end_day     = 31
+end_day     = 12
 
-timestep    = 72
-tolerance   = 5
+timestep    = 24
+tolerance   = 8
 
 [options]
 interval    = 24
-resolution  = 10
+resolution  = 20
 
-area_filter = True
+area_filter = False
 centre_lat  = 71
 centre_lon  = -160
 radius      = 700
@@ -93,5 +95,5 @@ visualise_timeseries = True
 visualise_interval   = True
 
 [netcdf_tools]
-plot_start_end_points = True
+plot_start_end_points = False
 plot_deformation      = True


### PR DESCRIPTION
Time series of coverage is now calculated either in area (millions of km^2) or in percentage of ocean points above a user-specified reference latitude. There is an added option in 'options.ini' so that the user can select if they want to plot the time series in percentage or area, and which reference latitude to use (lower than 50N will default to taking all available data and no percentage is calculated, only the total area). 

The map bins and map limits for computing the coverage (both the map and the time series) have also been modified to always remain the same, regardless of where the data is located (previously, the map boundary was changing with the min/max lat/lon of data points included in the map and the bins were not the same size between different plots). 

